### PR TITLE
Update DBM-Core.lua

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -2359,16 +2359,16 @@ bossModPrototype.AddMsg = DBM.AddMsg
 
 function bossModPrototype:SetZone(...)
 	if select("#", ...) == 0 then
-		if self.addon and self.addon.zone then
+		if self.addon.zone and #self.addon.zone > 0 and self.addon.zoneId and #self.addon.zoneId > 0 then
 			self.zones = {}
 			for i, v in ipairs(self.addon.zone) do
 				self.zones[#self.zones + 1] = v
 			end
-		end
-		if self.addon and self.addon.zoneId then
 			for i, v in ipairs(self.addon.zoneId) do
 				self.zones[#self.zones + 1] = v
 			end
+		else
+			self.zones = self.addon.zone and #self.addon.zone > 0 and self.addon.zone or self.addon.zoneId and #self.addon.zoneId > 0 and self.addon.zoneId or {}
 		end
 	elseif select(1, ...) ~= DBM_DISABLE_ZONE_DETECTION then
 		self.zones = {...}
@@ -3750,4 +3750,3 @@ do
 		return modLocalizations[name] or self:CreateModLocalization(name)
 	end
 end
-

--- a/DBM-Icecrown/TheFrozenThrone/LichKing.lua
+++ b/DBM-Icecrown/TheFrozenThrone/LichKing.lua
@@ -377,7 +377,7 @@ function mod:SPELL_CAST_SUCCESS(args)
 	elseif args:IsSpellID(73654, 74295, 74296, 74297) then -- Harvest Souls (Heroic)
 	--[[elseif args:IsSpellID(73654, 74295, 74296, 74297) then -- Harvest Souls (Heroic)]]--
 		specWarnHarvestSouls:Show()
-		timerHarvestSoulCD:Start(105) -- Custom edit to make Harvest Souls timers work again
+		timerHarvestSoulCD:Start(107) -- Custom edit to make Harvest Souls timers work again
 		timerVileSpirit:Cancel()
 		timerSoulreaperCD:Cancel()
 		timerDefileCD:Cancel()
@@ -549,7 +549,7 @@ function mod:NextPhase()
 	elseif phase == 3 then
 		timerVileSpirit:Start(20)
 		timerSoulreaperCD:Start(40)
-		timerDefileCD:Start(38)
+		timerDefileCD:Start(33)
 		timerHarvestSoulCD:Start(14)
 		warnDefileSoon:Schedule(33)
 	end


### PR DESCRIPTION
Remove Profiles support

The profiles module could cause several bugs:
DBM Special Raid Warnings turned all black and were barely readable
Sometimes completely disabled normal DBM Raid Warnings (raid warning with Defile target wouldn't show for example)
The profile "Default" couldn't be written to, so you still had to swap between profiles a lot if the above visual bugs didn't happen
It at least never was a quick and simple one-time-setup-for-all-chars as i would have hoped.
It's also why i removed it months ago from mine. Wish i saw this sooner.
After merging this pull request remove the entire DBM-Profiles folder please